### PR TITLE
Mac 10.15 requires extendedKeyUsage

### DIFF
--- a/options.conf
+++ b/options.conf
@@ -1,6 +1,7 @@
 authorityKeyIdentifier=keyid,issuer
 basicConstraints=CA:FALSE
 keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
 subjectAltName = @alt_names
 
 [alt_names]


### PR DESCRIPTION
I don't know if all 4 values are needed, but this seems fine to me.